### PR TITLE
Ajustes da conversão do IdCSC de Int16 p/ Int32

### DIFF
--- a/DFeBR.NFe/Servicos/Templates/ServAutorzTemplate.cs
+++ b/DFeBR.NFe/Servicos/Templates/ServAutorzTemplate.cs
@@ -314,7 +314,7 @@ namespace DFeBR.EmissorNFe.Servicos.Templates
             var dadosChave = Utils.ObterChave(estado, dataEHoraEmissao.LocalDateTime, cnpj, modeloDocumentoFiscal, serie, numeroDocumento,
                     tipoEmissao, codigoNumerico);
             entity.infNFe.Id = "NFe" + dadosChave.Chave;
-            entity.infNFe.ide.cDV = Convert.ToInt16(dadosChave.DigitoVerificador);
+            entity.infNFe.ide.cDV = Convert.ToInt32(dadosChave.DigitoVerificador);
         }
 
         /// <summary>

--- a/DFeBR.NFe/Utilidade/QrCodeNfCe.cs
+++ b/DFeBR.NFe/Utilidade/QrCodeNfCe.cs
@@ -54,7 +54,7 @@ namespace DFeBR.EmissorNFe.Utilidade
             var ambiente = (int) nfe.infNFe.ide.tpAmb;
 
             //Identificador do CSC (Código de Segurança do Contribuinte no Banco de Dados da SEFAZ). Informar sem os zeros não significativos
-            var idCsc = Convert.ToInt16(cIdToken);
+            var idCsc = Convert.ToInt32(cIdToken);
             string dadosBase;
             if (nfe.infNFe.ide.tpEmis == TipoEmissao.ContingenciaOffLineNfce)
             {


### PR DESCRIPTION
Ajuste do IdCSC na conversão para aceitar valores maiores que 32767 do Int16.